### PR TITLE
Allow us to pass in a recv size

### DIFF
--- a/battlefield_rcon/connection.py
+++ b/battlefield_rcon/connection.py
@@ -13,18 +13,19 @@ from battlefield_rcon.exceptions import RCONLoginRequiredException, RCONAuthExce
 
 
 class RCONConnection(object):
-    def __init__(self, remote_addr, port, password=None):
+    def __init__(self, remote_addr, port, password=None, recv_buffer=1024):
         self._remote_addr = remote_addr
         self._port = port
         self._password = password
         self._conn = None
         self._authenticated = False
         self._seq = 0
+        self.recv_buffer=int(recv_buffer)
 
     def _read_response(self):
         data_buffer = bytes()
         while not contains_complete_packet(data_buffer):
-            data_buffer += self._conn.recv(1024)
+            data_buffer += self._conn.recv(self.recv_buffer)
 
         return decode_packet(data_buffer)
 


### PR DESCRIPTION
I was noticing instability in a client when a server got larger than 10 people.  Every time there was a PunkBuster message that contained, I guess if everyone is still OK with PunkBuster, the loop would continue forever, never yielding.  Increasing the recv size to 8k fixed it for me, but I made it configurable.  I haven't seen any downside to making it 8k yet.